### PR TITLE
Add support for if/else gating behaviors

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,15 +1,36 @@
 package logif
 
-import "testing"
+import (
+	"log"
+	"os"
+	"testing"
+)
 
 func TestExample(t *testing.T) {
-	Debugf("hello %s", "user")
-	Infof("hello %s", "user")
-	Warningf("hello %s", "user")
-	Errorf("hello %s", "user")
+	log.SetOutput(os.Stdout)
+	Debugf("hello %s", "debug")
+	Infof("hello %s", "info")
+	Warningf("hello %s", "warning")
+	Errorf("hello %s", "error")
 
-	DefaultLogger.Debugf("hello %s", "user")
-	DefaultLogger.Infof("hello %s", "user")
-	DefaultLogger.Warningf("hello %s", "user")
-	DefaultLogger.Errorf("hello %s", "user")
+	DefaultLogger.Debugf("hello %s", "dl debug")
+	DefaultLogger.Infof("hello %s", "dl info")
+	DefaultLogger.Warningf("hello %s", "dl warning")
+	DefaultLogger.Errorf("hello %s", "dl error")
+
+	DefaultLogger.SetLevel(LevelDebug)
+	DefaultLogger.SetVerbosity(1)
+	DefaultLogger.V(1).Infof("level 1")
+	DefaultLogger.V(2).Infof("level 2 not shown")
+
+	if DefaultLogger.IsV(2) {
+		log.Printf("this line shouldn't print")
+		DefaultLogger.V(2).Infof("level 2 not shown")
+	}
+
+	DefaultLogger.SetVerbosity(3)
+	if DefaultLogger.IsV(2) {
+		log.Printf("this line should print")
+		DefaultLogger.V(2).Infof("level 2 shown when verbosity set to 3")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/oko/logif
+
+go 1.12

--- a/iface.go
+++ b/iface.go
@@ -22,6 +22,10 @@ type Logger interface {
 	V(int) Logger
 	// D returns a child logger that will only log DEBUG if its parent's level is less than or equal to its own
 	D(int) Logger
+	// IsV returns whether verbosity is set at the given level
+	IsV(int) bool
+	// IsD returns whether debugging is set at the given level
+	IsD(int) bool
 	// Verbosity returns the current verbosity level for INFO messages
 	Verbosity() int
 	// Debugging returns the current debugging level for DEBUG messages

--- a/stdlib.go
+++ b/stdlib.go
@@ -112,3 +112,19 @@ func (s *StdlibLogger) D(d int) Logger {
 		level:     s.level,
 	}
 }
+
+func (s *StdlibLogger) IsV(v int) bool {
+	if s.parent != nil {
+		return s.parent.IsV(v)
+	} else {
+		return v <= s.verbosity
+	}
+}
+
+func (s *StdlibLogger) IsD(d int) bool {
+	if s.parent != nil {
+		return s.parent.IsD(d)
+	} else {
+		return d <= s.debug
+	}
+}

--- a/stdlib_test.go
+++ b/stdlib_test.go
@@ -417,6 +417,71 @@ func TestStdlibLogger_V(t *testing.T) {
 	}
 }
 
+func TestStdlibLogger_IsV(t *testing.T) {
+	type fields struct {
+		verbosity int
+		debug     int
+		parent    *StdlibLogger
+		level     int
+	}
+	type args struct {
+		v int
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		args         args
+		shouldOutput bool
+	}{
+		{
+			"0",
+			fields{0, 0, nil, LevelInfo},
+			args{0},
+			true,
+		},
+		{
+			"0",
+			fields{0, 0, nil, LevelInfo},
+			args{1},
+			false,
+		},
+		{
+			"0",
+			fields{0, 0, nil, LevelInfo},
+			args{3},
+			false,
+		},
+		{
+			"0",
+			fields{3, 0, nil, LevelInfo},
+			args{3},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StdlibLogger{
+				verbosity: tt.fields.verbosity,
+				debug:     tt.fields.debug,
+				parent:    tt.fields.parent,
+				level:     tt.fields.level,
+			}
+			if s.IsV(tt.args.v) != tt.shouldOutput {
+				t.Errorf("IsV(%d) did not match expected output state: %t", tt.args.v, tt.shouldOutput)
+			}
+			if s.V(tt.args.v).IsV(tt.args.v) != tt.shouldOutput {
+				t.Errorf("IsV(%d) did not match expected output state: %t", tt.args.v, tt.shouldOutput)
+			}
+			if s.V(tt.args.v+1).IsV(tt.args.v) != tt.shouldOutput{
+				t.Errorf("IsV(%d) did not match expected output state: %t", tt.args.v, tt.shouldOutput)
+			}
+			if s.V(tt.args.v-1).IsV(tt.args.v) != tt.shouldOutput {
+				t.Errorf("IsV(%d) did not match expected output state: %t", tt.args.v, tt.shouldOutput)
+			}
+		})
+	}
+}
+
 func TestStdlibLogger_D(t *testing.T) {
 	type fields struct {
 		verbosity int
@@ -477,6 +542,72 @@ func TestStdlibLogger_D(t *testing.T) {
 				if buf.String() != "" {
 					t.Errorf("StdlibLogger.V(%d).Debugf(...) should not have printed but did", tt.args.d)
 				}
+			}
+		})
+	}
+}
+
+
+func TestStdlibLogger_IsD(t *testing.T) {
+	type fields struct {
+		verbosity int
+		debug     int
+		parent    *StdlibLogger
+		level     int
+	}
+	type args struct {
+		d int
+	}
+	tests := []struct {
+		name         string
+		fields       fields
+		args         args
+		shouldOutput bool
+	}{
+		{
+			"0 with 0 base",
+			fields{0, 0, nil, LevelDebug},
+			args{0},
+			true,
+		},
+		{
+			"1 with 0 base",
+			fields{0, 0, nil, LevelDebug},
+			args{1},
+			false,
+		},
+		{
+			"3 with 0 base",
+			fields{0, 0, nil, LevelDebug},
+			args{3},
+			false,
+		},
+		{
+			"3 with 3 base",
+			fields{0, 3, nil, LevelDebug},
+			args{3},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &StdlibLogger{
+				verbosity: tt.fields.verbosity,
+				debug:     tt.fields.debug,
+				parent:    tt.fields.parent,
+				level:     tt.fields.level,
+			}
+			if s.IsD(tt.args.d) != tt.shouldOutput {
+				t.Errorf("IsD(%d) did not match expected output state: %t", tt.args.d, tt.shouldOutput)
+			}
+			if s.D(tt.args.d).IsD(tt.args.d) != tt.shouldOutput {
+				t.Errorf("IsD(%d) did not match expected output state: %t", tt.args.d, tt.shouldOutput)
+			}
+			if s.D(tt.args.d+1).IsD(tt.args.d) != tt.shouldOutput{
+				t.Errorf("IsD(%d) did not match expected output state: %t", tt.args.d, tt.shouldOutput)
+			}
+			if s.D(tt.args.d-1).IsD(tt.args.d) != tt.shouldOutput {
+				t.Errorf("IsD(%d) did not match expected output state: %t", tt.args.d, tt.shouldOutput)
 			}
 		})
 	}


### PR DESCRIPTION
`glog` uses a type alias for `bool` to permit gating entire sections
of logic based on verbosity level. This is the syntax:

	if glog.V(2) {
		// ... do something
	}

Since `logif` is an interface to implementations, the API design has
to change slightly -- rather than aliasing bool and returning it for
the `V()` and `D()` functions, there are two additional functions
added to the interface, `IsV()` and `IsD()`. These functions return
`bool` permitting use of the same pattern, albeit with slightly less
elegance.